### PR TITLE
Allow disabling of server requirement

### DIFF
--- a/TSQL.tmLanguage
+++ b/TSQL.tmLanguage
@@ -61,7 +61,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?i:^\s*(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view|proc|procedure))</string>
+			<string>(?i:^\s*(drop)\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view|procedure|proc))</string>
 			<key>name</key>
 			<string>meta.drop.sql</string>
 		</dict>

--- a/TSQLEasy.sublime-settings
+++ b/TSQLEasy.sublime-settings
@@ -4,11 +4,12 @@
         "Main": {
             "driver": "SQL Server",
             "server": "127.0.0.1",
-            "server_port": "1433",
+            "server_port": "1521",
             "username": "",
             "password": "",
             "database": "",
-            "autocommit": true
+            "autocommit": false,
+            "enable_connection": false
             },
         "Offline": {
             "driver": ""

--- a/tsqleasy.py
+++ b/tsqleasy.py
@@ -86,8 +86,9 @@ def te_get_connection():
         database = server_list[server_active]['database']
         autocommit = server_list[server_active]['autocommit'] if 'autocommit' in server_list[server_active] else True
         timeout = server_list[server_active]['timeout'] if 'timeout' in server_list[server_active] else 0
-
-        sqlcon = sqlodbccon.SQLCon(server=server, driver=driver, serverport=server_port, username=username, password=password, database=database, sleepsecs="5", autocommit=autocommit, timeout=timeout)
+        enable_con = server_list[server_active]['enable_connection'] if 'enable_connection' in server_list[server_active] else False
+        if enable_con:
+            sqlcon = sqlodbccon.SQLCon(server=server, driver=driver, serverport=server_port, username=username, password=password, database=database, sleepsecs="5", autocommit=autocommit, timeout=timeout)
         return sqlcon
     else:
         return None


### PR DESCRIPTION
I've added an extra field into the TSQLEasy settings which lets you completely disable the requirement for network connectivity. I really needed this plugin just for syntax highlighting :)  I don't know if it will be of any use but if you think it's any good it's all yours.

Thanks,
Chris