### PR TITLE
Add new keywords and funcs

### DIFF
--- a/TSQL.tmLanguage
+++ b/TSQL.tmLanguage
@@ -7,6 +7,7 @@
         <string>sql</string>
         <string>ddl</string>
         <string>dml</string>
+        <string>tsql</string>
     </array>
     <key>foldingStartMarker</key>
     <string>\s*\(\s*$</string>
@@ -223,13 +224,13 @@
                 |\b(char|varchar\d?)\b(?:\((\d+)\))?
 
                 # special case, capture 6 + 7i + 8i
-                |\b(numeric)\b(?:\((\d+),(\d+)\))?
+                |\b(numeric|decimal)\b(?:\((\d+),(\d+)\))?
 
                 # special case, captures 9, 10i, 11
-                |\b(times)(?:\((\d+)\))(\swithoutstimeszone\b)?
+                |\b(times)(?:\((\d+)\))(\swith(?:out)?\stime\szone\b)?
 
                 # special case, captures 12, 13, 14i, 15
-                |\b(timestamp)(?:(s)\((\d+)\)(\swithoutstimeszone\b)?)?
+                |\b(timestamp)(?:(s)\((\d+)\)(\swith(?:out)?\stime\szone\b)?)?
 
             </string>
         </dict>
@@ -283,17 +284,17 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Reserved keywords: https://msdn.microsoft.com/en-us/library/ms189822.aspx</string>
+            <string>Reserved keywords: https://docs.microsoft.com/en-us/sql/t-sql/language-elements/reserved-keywords-transact-sql</string>
             <key>match</key>
-            <string>(?i:\b(add|external|procedure|all|fetch|public|alter|file|raiserror|and|fillfactor|read|any|for|readtext|as|foreign|reconfigure|asc|freetext|references|authorization|freetexttable|replication|backup|from|restore|begin|full|restrict|between|function|return|break|goto|revert|browse|grant|revoke|bulk|group|right|by|having|rollback|cascade|holdlock|rowcount|case|identity|rowguidcol|check|identity_insert|rule|checkpoint|identitycol|save|close|if|schema|clustered|in|securityaudit|coalesce|index|select|collate|inner|semantickeyphrasetable|column|insert|semanticsimilaritydetailstable|commit|intersect|semanticsimilaritytable|compute|into|session_user|constraint|is|set|contains|join|setuser|containstable|key|shutdown|continue|kill|some|convert|left|statistics|create|like|system_user|cross|lineno|table|current|load|tablesample|current_date|merge|textsize|current_time|national|then|current_timestamp|nocheck|to|current_user|nonclustered|top|cursor|not|tran|database|null|transaction|dbcc|nullif|trigger|deallocate|of|truncate|declare|off|try_convert|default|offsets|tsequal|delete|on|union|deny|open|unique|desc|opendatasource|unpivot|disk|openquery|update|distinct|openrowset|updatetext|distributed|openxml|use|double|option|user|drop|or|values|dump|order|varying|else|outer|view|end|over|waitfor|errlvl|percent|when|escape|pivot|where|except|plan|while|exec|precision|with|execute|primary|within group|exists|print|writetext|exit|proc)\b)</string>
+            <string>(?i:\b(add|external|procedure|all|fetch|public|alter|file|raiserror|and|fillfactor|read|any|for|readtext|as|foreign|reconfigure|asc|freetext|references|authorization|freetexttable|replication|backup|from|restore|begin|full|restrict|between|function|return|break|goto|revert|browse|grant|revoke|bulk|group|right|by|having|rollback|cascade|holdlock|rowcount|case|identity|rowguidcol|check|identity_insert|rule|checkpoint|identitycol|save|close|if|schema|clustered|in|securityaudit|coalesce|index|select|collate|inner|semantickeyphrasetable|column|insert|semanticsimilaritydetailstable|commit|intersect|semanticsimilaritytable|compute|into|session_user|constraint|is|set|contains|join|setuser|containstable|key|shutdown|continue|kill|some|convert|left|statistics|create|like|system_user|cross|lineno|table|current|load|tablesample|current_date|merge|textsize|current_time|national|then|current_timestamp|nocheck|to|current_user|nonclustered|top|cursor|not|tran|database|null|transaction|dbcc|nullif|trigger|deallocate|of|truncate|declare|off|try_convert|default|offsets|tsequal|delete|on|union|deny|open|unique|desc|opendatasource|unpivot|disk|openquery|update|distinct|openrowset|updatetext|distributed|openxml|use|double|option|user|drop|or|values|dump|order|varying|else|outer|view|end|over|waitfor|errlvl|percent|when|escape|pivot|where|except|plan|while|exec|precision|with|execute|primary|within\sgroup|exists|print|writetext|exit|proc)\b)</string>
             <key>name</key>
             <string>keyword.other.reserved.sql</string>
         </dict>
         <dict>
             <key>comment</key>
-            <string>Control-of-flow keywords: https://msdn.microsoft.com/en-us//library/ms174290.aspx</string>
+            <string>Control-of-flow keywords: https://docs.microsoft.com/en-us/sql/t-sql/language-elements/control-of-flow</string>
             <key>match</key>
-            <string>(?i:\b(BEGIN|END|RETURN|break|THROW|CONTINUE|TRY|CATCH|GOTO|WAITFOR|IF|ELSE|WHILE)\b)</string>
+            <string>(?i:\b(begin|end|return|break|throw|continue|try|catch|goto|waitfor|if|else|while)\b)</string>
             <key>name</key>
             <string>keyword.other.reserved.sql</string>
         </dict>
@@ -367,7 +368,7 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Rowset functions: https://msdn.microsoft.com/en-us/library/ms187957.aspx</string>
+            <string>Rowset functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/rowset-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)\b(opendatasource|openrowset|openquery|openxml)\b</string>
             <key>name</key>
@@ -375,7 +376,7 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Aggregate Functions: https://msdn.microsoft.com/en-us/library/ms173454.aspx</string>
+            <string>Aggregate Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/aggregate-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)\b(avg|min|checksum_agg|sum|count|stdev|count_big|stdevp|grouping|var|grouping_id|varp|max)\b</string>
             <key>name</key>
@@ -383,7 +384,7 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Ranking Functions: https://msdn.microsoft.com/en-us/library/ms189798.aspx</string>
+            <string>Ranking Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/ranking-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)\b(rank|ntile|dense_rank|row_number)\b</string>
             <key>name</key>
@@ -391,7 +392,23 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Configuration Functions: https://msdn.microsoft.com/en-us/library/ms173823.aspx</string>
+            <string>Analytic Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/analytic-functions-transact-sql</string>
+            <key>match</key>
+            <string>(?i)\b(cume_dist|lead|first_value|percentile_cont|lag|percentile_disc|last_value|percent_rank)\b</string>
+            <key>name</key>
+            <string>support.function.analytic.sql</string>
+        </dict>
+        <dict>
+            <key>comment</key>
+            <string>Collation Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/collation-functions-collationproperty-transact-sql</string>
+            <key>match</key>
+            <string>(?i)\b(collationproperty|tertiary_weights)\b</string>
+            <key>name</key>
+            <string>support.function.collation.sql</string>
+        </dict>
+        <dict>
+            <key>comment</key>
+            <string>Configuration Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/configuration-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)@@\b(datefirst|options|dbts|remserver|langid|servername|language|servicename|lock_timeout|spid|max_connections|textsize|max_precision|version|nestlevel)\b</string>
             <key>name</key>
@@ -399,7 +416,7 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Conversion Functions: https://msdn.microsoft.com/en-us/library/hh231076.aspx</string>
+            <string>Conversion Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/conversion-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)\b(cast|convert|parse|try_cast|try_convert|try_parse)\b</string>
             <key>name</key>
@@ -407,7 +424,15 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Cursor Functions: https://msdn.microsoft.com/en-us/library/ms186285.aspx</string>
+            <string>Cryptographic Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/cryptographic-functions-transact-sql</string>
+            <key>match</key>
+            <string>(?i)\b(encryptbykey|decryptbykey|encryptbypassphrase|decryptbypassphrase|key_id|key_guid|decryptbykeyautoasymkey|key_name|symkeyproperty|encryptbyasymkey|decryptbyasymkey|encryptbycert|decryptbycert|asymkeyproperty|asymkey_id|signbyasymkey|verifysignedbyasmkey|signbycert|verigysignedbycert|is_objectsigned|decryptbykeyautocert|hashbytes)\b</string>
+            <key>name</key>
+            <string>support.function.crypto.sql</string>
+        </dict>
+        <dict>
+            <key>comment</key>
+            <string>Cursor Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/cursor-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)(@@\b(cursor_rows|fetch_status)|cursor_status)\b</string>
             <key>name</key>
@@ -415,15 +440,31 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Date and time Functions: https://msdn.microsoft.com/en-us/library/ms186724.aspx</string>
+            <string>Data Type Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/data-type-functions-transact-sql</string>
             <key>match</key>
-            <string>(?i)\b(sysdatetime|sysdatetimeoffset|sysutcdatetime|current_timestamp|getdate|getutcdate|datename|datepart|day|month|year|datefromparts|datetime2fromparts|datetimefromparts|datetimeoffsetfromparts|smalldatetimefromparts|timefromparts|datediff|dateadd|eomonth|switchoffset|todatetimeoffset|isdate)|@@\b(datefirst|language)\b</string>
+            <string>(?i)(@@\b(datalength|ident_seed|ident_current|identity|ident_incr|sql_variant_property)\b</string>
+            <key>name</key>
+            <string>support.function.datatype.sql</string>
+        </dict>
+        <dict>
+            <key>comment</key>
+            <string>Date and time Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/date-and-time-data-types-and-functions-transact-sql</string>
+            <key>match</key>
+            <string>(?i)\b(sysdatetime|sysdatetimeoffset|sysutcdatetime|current_timestamp|getdate|getutcdate|datename|datepart|day|month|year|datefromparts|datetime2fromparts|datetimefromparts|datetimeoffsetfromparts|smalldatetimefromparts|timefromparts|datediff|datediff_big|dateadd|eomonth|switchoffset|todatetimeoffset|isdate)|@@\b(datefirst|language)\b</string>
             <key>name</key>
             <string>support.function.datetime.sql</string>
         </dict>
         <dict>
             <key>comment</key>
-            <string>Logical Functions: https://msdn.microsoft.com/en-us/library/hh213226.aspx</string>
+            <string>JSON Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/json-functions-transact-sql</string>
+            <key>match</key>
+            <string>(?i)\b(isjson|json_value|json_query|json_modify)\b</string>
+            <key>name</key>
+            <string>support.function.json.sql</string>
+        </dict>
+        <dict>
+            <key>comment</key>
+            <string>Logical Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/logical-functions-choose-transact-sql</string>
             <key>match</key>
             <string>(?i)\b(choose|iif)\b</string>
             <key>name</key>
@@ -431,7 +472,7 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Mathematical Functions: https://msdn.microsoft.com/en-us/library/ms177516.aspx</string>
+            <string>Mathematical Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/mathematical-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)\b(abs|degrees|rand|acos|exp|round|asin|floor|sign|atan|log|sin|atn2|log10|sqrt|ceiling|pi|square|cos|power|tan|cot|radians)\b</string>
             <key>name</key>
@@ -439,7 +480,7 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Metadata Functions: https://msdn.microsoft.com/en-us/library/ms187812.aspx</string>
+            <string>Metadata Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/metadata-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)@@\b(procid)|\b(index_col|app_name|indexkey_property|applock_mode|indexproperty|applock_test|next value for|assemblyproperty|object_definition|col_length|object_id|col_name|object_name|columnproperty|object_schema_name|database_principal_id|objectproperty|databasepropertyex|objectpropertyex|db_id|original_db_name|db_name|parsename|file_id|schema_id|file_idex|schema_name|file_name|scope_identity|filegroup_id|serverproperty|filegroup_name|stats_date|filegroupproperty|type_id|fileproperty|type_name|fulltextcatalogproperty|typeproperty|fulltextserviceproperty)\b</string>
             <key>name</key>
@@ -447,7 +488,15 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Security Functions: https://msdn.microsoft.com/en-us/library/ms186236.aspx</string>
+            <string>Replication Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/replication-functions-publishingservername</string>
+            <key>match</key>
+            <string>(?i)\b(publishingservername)\b</string>
+            <key>name</key>
+            <string>support.function.replication.sql</string>
+        </dict>
+        <dict>
+            <key>comment</key>
+            <string>Security Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/security-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)\b(certencoded|pwdcompare|certprivatekey|pwdencrypt|current_user|schema_id|database_principal_id|schema_name|session_user|suser_id|suser_sid|has_perms_by_name|suser_sname|is_member|system_user|is_rolemember|suser_name|is_srvrolemember|user_id|original_login|user_name|permissions)\b</string>
             <key>name</key>
@@ -455,15 +504,15 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>String Functions: https://msdn.microsoft.com/en-us/library/ms181984.aspx</string>
+            <string>String Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/string-functions-transact-sql</string>
             <key>match</key>
-            <string>(?i)\b(ascii|ltrim|soundex|char|nchar|space|charindex|patindex|str|concat|quotename|stuff|difference|replace|substring|format|replicate|unicode|left|reverse|upper|len|right|lower|rtrim)\b</string>
+            <string>(?i)\b(ascii|char|charindex|concat|concat_ws|difference|format|left|len|lower|ltrim|nchar|patindex|quotename|replace|replicate|reverse|right|rtrim|soundex|space|str|string_agg|string_escape|string_split|stuff|substring|translate|trim|unicode|upper)\b</string>
             <key>name</key>
             <string>support.function.string.sql</string>
         </dict>
         <dict>
             <key>comment</key>
-            <string>System Functions: https://msdn.microsoft.com/en-us/library/ms187786.aspx</string>
+            <string>System Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/system-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)\$\b(partition)|@@\b(error|identity|pack_received|rowcount|trancount)|\b(error_severity|error_state|formatmessage|getansinull|get_filestream_transaction_context|host_id|binary_checksum|host_name|checksum|isnull|connectionproperty|isnumeric|context_info|min_active_rowversion|current_request_id|newid|error_line|newsequentialid|error_message|rowcount_big|error_number|xact_state|error_procedure)\b</string>
             <key>name</key>
@@ -471,7 +520,7 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>System Statistical Functions: https://msdn.microsoft.com/en-us/library/ms177520.aspx</string>
+            <string>System Statistical Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/system-statistical-functions-transact-sql</string>
             <key>match</key>
             <string>(?i)@@\b(connections|pack_received|cpu_busy|pack_sent|timeticks|idle|total_errors|io_busy|total_read|packet_errors|total_write)\b</string>
             <key>name</key>
@@ -479,11 +528,11 @@
         </dict>
         <dict>
             <key>comment</key>
-            <string>Text and image Functions: https://msdn.microsoft.com/en-us/library/ms188353.aspx</string>
+            <string>Text and image Functions: https://docs.microsoft.com/en-us/sql/t-sql/functions/text-and-image-functions-textptr-transact-sql</string>
             <key>match</key>
             <string>(?i)\b(patindex|textvalid|textptr)\b</string>
             <key>name</key>
-            <string>support.function.text&amp;image.sql</string>
+            <string>support.function.text-image.sql</string>
         </dict>
         <dict>
             <key>include</key>


### PR DESCRIPTION
Updated tsql.tmLanguage with the following changes:

- Updated to current Microsoft URLs for T-SQL docs
- Updated keywords to match Microsoft's current feature set
- Added new/missing keyword sections for cryptography, json, analytics, collation
- Minor fixes for some legacy bugs (swithoutstimeszone -> \swithout\stime\szone), etc.
- Minor casing and formatting for consistency